### PR TITLE
Disable logging multiline fields by default

### DIFF
--- a/logging/README.md
+++ b/logging/README.md
@@ -72,7 +72,7 @@ The default logging behavior can be configured by the following environment vari
 | LOG_COLORIZE                 | true    | Colorize log messages by level when true. Works with `console` encoding only. |
 | LOG_SHORT_TIME               | false   | Omit date from timestamp when true. Works with `console` encoding only. |
 | LOG_DISPLAY_FIELDS           | true    | Omit log fields from output when false. Works with `console` encoding only. |
-| LOG_DISPLAY_MULTILINE_FIELDS | true    | Print fields on one line when true, one field per line when false. Works with `console` encoding only. |
+| LOG_DISPLAY_MULTILINE_FIELDS | false   | Print fields on one line when true, one field per line when false. Works with `console` encoding only. |
 
 ## Adapters
 

--- a/logging/config.go
+++ b/logging/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	LogInitialFields          Fields `env:"LOG_FIELDS"`
 	LogShortTime              bool   `env:"LOG_SHORT_TIME" default:"false"`
 	LogDisplayFields          bool   `env:"LOG_DISPLAY_FIELDS" default:"true"`
-	LogDisplayMultilineFields bool   `env:"LOG_DISPLAY_MULTILINE_FIELDS" default:"true"`
+	LogDisplayMultilineFields bool   `env:"LOG_DISPLAY_MULTILINE_FIELDS" default:"false"`
 	RawLogFieldBlacklist      string `env:"LOG_FIELD_BLACKLIST"`
 	LogFieldBlacklist         []string
 }


### PR DESCRIPTION
The multiline fields make it hard to read log messages because they're so split up.  I think they should be turned off by default with the option to turn them on if you need to seem the fields easier.